### PR TITLE
[#23611] Upgrade Linters CI runner image to `ubuntu-24.04`

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -18,7 +18,7 @@
 #     - execute clang-tidy check
 #
 #   - uncrustify
-#     - ubuntu-22.04
+#     - ubuntu-24.04
 #     - test uncrustify
 #
 #   - python-linter
@@ -183,7 +183,7 @@ jobs:
 # UNCRUSTIFY
 
   uncrustify:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
       - name: Uncrustify


### PR DESCRIPTION

## Description

Upgraded runner image to ```ubuntu-24.04```. Now using ```Uncrustify-0.78.1_f``` the new default _uncrustify_ version for this image.