### PR TITLE
[#24607] Fix macOS/Clang debug warnings

### DIFF
--- a/ddsenabler_participants/include/ddsenabler_participants/rpc/RpcStructs.hpp
+++ b/ddsenabler_participants/include/ddsenabler_participants/rpc/RpcStructs.hpp
@@ -39,7 +39,7 @@ enum class ActionEraseReason
 
 struct RpcAction
 {
-    RpcAction() = default;
+    RpcAction() = delete;
     RpcAction(
             const std::string& action_name,
             const ddspipe::core::types::RpcTopic& goal,


### PR DESCRIPTION
## Description
This PR fixes a macOS/Clang warning in ddsenabler_participants by deleting the default constructor of RpcAction.

## Problem
RpcAction declared:
RpcAction() = default;
but the type contains several ddspipe::core::types::RpcTopic members, and RpcTopic is not default-constructible. 

### On Clang, this triggers:

_-Wdefaulted-function-deleted_
warning that the explicitly defaulted constructor is implicitly deleted